### PR TITLE
Correctly parse the content type when it contains parameters

### DIFF
--- a/src/JsonDecoder.php
+++ b/src/JsonDecoder.php
@@ -8,12 +8,13 @@ class JsonDecoder
 {
     public function __invoke(Request $request, Response $response, callable $next)
     {
-        $type   = $request->getHeader('Content-Type');
+        $parts  = explode(';', $request->getHeaderLine('Content-Type'));
+        $type   = trim(array_shift($parts));
         $method = $request->getMethod();
 
         if ('GET' != $method
             && ! empty($type)
-            && 'application/json' == strtolower($type[0])
+            && 'application/json' == strtolower($type)
         ) {
             $body    = (string) $request->getBody();
             $request = $request->withParsedBody(json_decode($body));

--- a/tests/JsonDecoderTest.php
+++ b/tests/JsonDecoderTest.php
@@ -18,12 +18,20 @@ class JsonDecoderTest extends \PHPUnit_Framework_TestCase
             ['GET'   , 'application/json', []],
             ['GET'   , null, []],
             ['POST'  , 'application/json', $this->data],
+            ['POST'  , 'application/json; charset=utf-8', $this->data],
+            ['POST'  , 'application/json ; charset=utf-8', $this->data],
             ['POST'  , null, []],
             ['PUT'   , 'application/json', $this->data],
+            ['PUT'   , 'application/json; charset=utf-8', $this->data],
+            ['PUT'   , 'application/json ; charset=utf-8', $this->data],
             ['PUT'   , null, []],
             ['PATCH' , 'application/json', $this->data],
+            ['PATCH' , 'application/json; charset=utf-8', $this->data],
+            ['PATCH' , 'application/json ; charset=utf-8', $this->data],
             ['PATCH' , null, []],
             ['other' , 'application/json', $this->data],
+            ['other' , 'application/json; charset=utf-8', $this->data],
+            ['other' , 'application/json ; charset=utf-8', $this->data],
             ['other' , null, []]
         ];
     }


### PR DESCRIPTION
Media types in the content-type header may contain parameters (see https://tools.ietf.org/html/rfc7231#section-3.1.1.1). A typical example would be: `application/json; charset=utf-8`. This PR fixes the JsonDecoder to correctly parse the type/subtype part from header values that contain such parameters.
