### PR TITLE
Add access to json_decode assoc property + tests

### DIFF
--- a/src/JsonDecoder.php
+++ b/src/JsonDecoder.php
@@ -10,7 +10,7 @@ class JsonDecoder
     protected $maxDepth;
     protected $options;
     
-    public function __construct($assoc = false, $max_depth = 256, $options = 0)
+    public function __construct($assoc = false, $maxDepth = 256, $options = 0)
     {
         $this->assoc = $assoc;
         $this->max_depth = $maxDepth;

--- a/src/JsonDecoder.php
+++ b/src/JsonDecoder.php
@@ -6,10 +6,14 @@ use Psr\Http\Message\ServerRequestInterface as Request;
 
 class JsonDecoder
 {
-    private $assoc;
+    protected $assoc;
+    protected $max_depth;
+    protected $options;
     
-    public function __construct($assoc = 0){
+    public function __construct($assoc = false, $max_depth = 256, $options = 0){
         $this->assoc = $assoc;
+        $this->max_depth = $max_depth;
+        $this->options = $options;
     }
     
     public function __invoke(Request $request, Response $response, callable $next)
@@ -23,7 +27,10 @@ class JsonDecoder
             && 'application/json' == strtolower($type)
         ) {
             $body    = (string) $request->getBody();
-            $request = $request->withParsedBody(json_decode($body, $this->assoc));
+            $request = $request->withParsedBody(json_decode($body,
+                                                            $this->assoc,
+                                                            $this->max_depth,
+                                                            $this->options));
         }
 
         return $next($request, $response);

--- a/src/JsonDecoder.php
+++ b/src/JsonDecoder.php
@@ -10,7 +10,8 @@ class JsonDecoder
     protected $maxDepth;
     protected $options;
     
-    public function __construct($assoc = false, $max_depth = 256, $options = 0){
+    public function __construct($assoc = false, $max_depth = 256, $options = 0)
+    {
         $this->assoc = $assoc;
         $this->max_depth = $maxDepth;
         $this->options = $options;

--- a/src/JsonDecoder.php
+++ b/src/JsonDecoder.php
@@ -7,12 +7,12 @@ use Psr\Http\Message\ServerRequestInterface as Request;
 class JsonDecoder
 {
     protected $assoc;
-    protected $max_depth;
+    protected $maxDepth;
     protected $options;
     
     public function __construct($assoc = false, $max_depth = 256, $options = 0){
         $this->assoc = $assoc;
-        $this->max_depth = $max_depth;
+        $this->max_depth = $maxDepth;
         $this->options = $options;
     }
     
@@ -29,7 +29,7 @@ class JsonDecoder
             $body    = (string) $request->getBody();
             $request = $request->withParsedBody(json_decode($body,
                                                             $this->assoc,
-                                                            $this->max_depth,
+                                                            $this->maxDepth,
                                                             $this->options));
         }
 

--- a/src/JsonDecoder.php
+++ b/src/JsonDecoder.php
@@ -6,6 +6,12 @@ use Psr\Http\Message\ServerRequestInterface as Request;
 
 class JsonDecoder
 {
+    private $assoc;
+    
+    public function __construct($assoc = 0){
+        $this->assoc = $assoc;
+    }
+    
     public function __invoke(Request $request, Response $response, callable $next)
     {
         $parts  = explode(';', $request->getHeaderLine('Content-Type'));
@@ -17,7 +23,7 @@ class JsonDecoder
             && 'application/json' == strtolower($type)
         ) {
             $body    = (string) $request->getBody();
-            $request = $request->withParsedBody(json_decode($body));
+            $request = $request->withParsedBody(json_decode($body, $this->assoc));
         }
 
         return $next($request, $response);

--- a/src/JsonDecoder.php
+++ b/src/JsonDecoder.php
@@ -13,7 +13,7 @@ class JsonDecoder
     public function __construct($assoc = false, $maxDepth = 256, $options = 0)
     {
         $this->assoc = $assoc;
-        $this->max_depth = $maxDepth;
+        $this->maxDepth = $maxDepth;
         $this->options = $options;
     }
     

--- a/tests/JsonDecoderTest.php
+++ b/tests/JsonDecoderTest.php
@@ -10,38 +10,104 @@ class JsonDecoderTest extends \PHPUnit_Framework_TestCase
 {
 
     protected $data = ['foo', 'bar'];
+    protected $dataAssoc = ['foo'=>'baz', 'bar'=>'qux'];
 
 
     public function requestProvider()
     {
         return [
-            ['GET'   , 'application/json', []],
-            ['GET'   , null, []],
-            ['POST'  , 'application/json', $this->data],
-            ['POST'  , 'application/json; charset=utf-8', $this->data],
-            ['POST'  , 'application/json ; charset=utf-8', $this->data],
-            ['POST'  , null, []],
-            ['PUT'   , 'application/json', $this->data],
-            ['PUT'   , 'application/json; charset=utf-8', $this->data],
-            ['PUT'   , 'application/json ; charset=utf-8', $this->data],
-            ['PUT'   , null, []],
-            ['PATCH' , 'application/json', $this->data],
-            ['PATCH' , 'application/json; charset=utf-8', $this->data],
-            ['PATCH' , 'application/json ; charset=utf-8', $this->data],
-            ['PATCH' , null, []],
-            ['other' , 'application/json', $this->data],
-            ['other' , 'application/json; charset=utf-8', $this->data],
-            ['other' , 'application/json ; charset=utf-8', $this->data],
-            ['other' , null, []]
+            ['GET'   , 'application/json', [],[]],
+            ['GET'   , null, [],[]],
+            ['POST'  , 'application/json', $this->data, $this->dataAssoc],
+            ['POST'  , 'application/json; charset=utf-8', $this->data, $this->dataAssoc],
+            ['POST'  , 'application/json ; charset=utf-8',$this->data, $this->dataAssoc],
+            ['POST'  , null, [], []],
+            ['PUT'   , 'application/json', $this->data, $this->dataAssoc],
+            ['PUT'   , 'application/json; charset=utf-8', $this->data, $this->dataAssoc],
+            ['PUT'   , 'application/json ; charset=utf-8', $this->data, $this->dataAssoc],
+            ['PUT'   , null, [], []],
+            ['PATCH' , 'application/json', $this->data, $this->dataAssoc],
+            ['PATCH' , 'application/json; charset=utf-8', $this->data, $this->dataAssoc],
+            ['PATCH' , 'application/json ; charset=utf-8', $this->data, $this->dataAssoc],
+            ['PATCH' , null, [], []],
+            ['other' , 'application/json', $this->data, $this->dataAssoc],
+            ['other' , 'application/json; charset=utf-8', $this->data, $this->dataAssoc],
+            ['other' , 'application/json ; charset=utf-8', $this->data, $this->dataAssoc],
+            ['other' , null, [], []]
         ];
     }
 
     /**
      * @dataProvider requestProvider
      */
-    public function testParser($method, $contentType, $expected)
+    public function testParser($method, $contentType, $expected, $alt)
     {
         $json = json_encode($this->data);
+
+        $stream = new Stream('php://temp', 'wb+');
+        $stream->write($json);
+
+        $jsonDecoder = new JsonDecoder();
+
+        $response = new Response();
+        $request = ServerRequestFactory::fromGlobals()
+            ->withMethod($method)
+            ->withBody($stream);
+
+        if ($contentType) {
+            $request = $request->withHeader('Content-Type', $contentType);
+        }
+
+        $parsedRequest = $jsonDecoder(
+            $request,
+            $response,
+            function ($request, $response) {
+                return $request;
+            }
+        );
+
+        $this->assertEquals($expected, $parsedRequest->getParsedBody());
+    }
+    
+    /**
+     * @dataProvider requestProvider
+     */
+    public function testDecodeToAssoc($method, $contentType, $alt, $expected)
+    {
+        $json = json_encode($this->dataAssoc);
+
+        $stream = new Stream('php://temp', 'wb+');
+        $stream->write($json);
+
+        $jsonDecoder = new JsonDecoder(true);
+
+        $response = new Response();
+        $request = ServerRequestFactory::fromGlobals()
+            ->withMethod($method)
+            ->withBody($stream);
+
+        if ($contentType) {
+            $request = $request->withHeader('Content-Type', $contentType);
+        }
+
+        $parsedRequest = $jsonDecoder(
+            $request,
+            $response,
+            function ($request, $response) {
+                return $request;
+            }
+        );
+
+        $this->assertEquals($expected, $parsedRequest->getParsedBody());
+    }
+    
+    /**
+     * @dataProvider requestProvider
+     */
+    public function testDecodeToObject($method, $contentType, $alt, $expected)
+    {
+        $expected = $expected?(object) $expected:[];
+        $json = json_encode($this->dataAssoc);
 
         $stream = new Stream('php://temp', 'wb+');
         $stream->write($json);


### PR DESCRIPTION
Allows specification of decode style at the time of construction of JsonDecoder

$jsonDecoder = new JsonDecoder(true);
