### PR TITLE
Improve content handling middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ This package include the following Relay-compatible middleware:
 
 - _ResponseSender_ to send a PSR-7 response
 - _ExceptionHandler_ to handle exceptions from subsequent middleware
-- _JsonDecoder_ to deserialize the JSON payload of a PSR-7 request
+- _JsonContentHandler_ to deserialize the JSON payload of a PSR-7 request
+- _JsonDecoder_ to deserialize the JSON payload of a PSR-7 request (**deprecated**)
 
 This package is installable and PSR-4 autoloadable via Composer as `relay/middleware`.
 
@@ -40,7 +41,43 @@ $queue = new \Relay\Middleware\ExceptionHandler(new ResponseImplementation());
 
 ... or use a `$resolver` of your choice to instantiate it from the `$queue`.
 
+## JsonContentHandler
+
+Again, the _JsonContentHandler_ does what it sounds like: it deserializes the JSON
+payload of a PSR-7 request object and makes the parameters available in
+subsequent middleware decorators.
+
+The _JsonContentHandler_ checks the incoming request for a method other than `GET`
+and for an `application/json` or `application/vnd.api+json` `Content-Type` header.
+If it finds both of these, it parses the JSON and makes it available as the
+_parsed body_ of the `$request` before passing it and the `$response` to `$next`.
+If the method is `GET` or the `Content-Type` header defines a different mime type,
+the _JsonContentHandler_ ignores the `$request` and continues the chain.
+
+To add the _JsonContentHandler_ to your queue, instantiate it directly...
+
+```php
+$queue = new \Relay\Middleware\JsonContentHandler();
+```
+
+... or use a `$resolver` of your choice to instantiate it from the `$queue`.
+
+To access the decoded parameters in subsequent middleware, use the
+`getParsedBody()` method of the `$request`
+
+```php
+$decodedJsonData = $request->getParsedBody();
+```
+
+## FormContentHandler
+
+_FormContentHandler_ works almost identically to _JsonContentHandler_, but parses
+payloads of requests that have `application/x-www-form-urlencoded` as the `Content-Type`.
+
+
 ## JsonDecoder
+
+**NOTE: This handler has been deprecated in favor of _JsonContentHandler_!**
 
 Again, the _JsonDecoder_ does what it sounds like: it deserializes the JSON
 payload of a PSR-7 request object and makes the parameters available in

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
         }
     },
     "require-dev": {
-        "zendframework/zend-diactoros": "~1.0"
+        "zendframework/zend-diactoros": "~1.0",
+        "phpunit/phpunit": "4.8 - 5.0"
     },
     "autoload-dev": {
         "psr-4": {

--- a/src/ContentHandler.php
+++ b/src/ContentHandler.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Relay\Middleware;
+
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+
+use RuntimeException;
+
+abstract class ContentHandler
+{
+    /**
+     * @var array Methods that cannot have request bodies
+     */
+    protected $httpMethodsWithoutContent = [
+        'GET',
+        'HEAD',
+    ];
+
+    /**
+     * Check if the content type is appropriate for handling
+     *
+     * @param string $mime
+     *
+     * @return boolean
+     */
+    abstract protected function isApplicableMimeType($mime);
+
+    /**
+     * Parse the request body
+     *
+     * @uses throwException()
+     *
+     * @param string $body
+     *
+     * @return mixed
+     */
+    abstract protected function getParsedBody($body);
+
+    /**
+     * Throw an exception when parsing fails
+     *
+     * @param string $message
+     *
+     * @return void
+     *
+     * @throws \RuntimeException
+     */
+    protected function throwException($message)
+    {
+        throw new RuntimeException($message);
+    }
+
+    /**
+     * Parses request bodies based on content type
+     *
+     * @param  Request  $request
+     * @param  Response $response
+     * @param  callable $next
+     * @return Response
+     */
+    public function __invoke(Request $request, Response $response, callable $next)
+    {
+        if (!in_array($request->getMethod(), $this->httpMethodsWithoutContent)) {
+            $parts = explode(';', $request->getHeaderLine('Content-Type'));
+            $mime  = strtolower(trim(array_shift($parts)));
+
+            if ($this->isApplicableMimeType($mime) && !$request->getParsedBody()) {
+                $parsed  = $this->getParsedBody((string) $request->getBody());
+                $request = $request->withParsedBody($parsed);
+            }
+        }
+
+        return $next($request, $response);
+    }
+}

--- a/src/FormContentHandler.php
+++ b/src/FormContentHandler.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Relay\Middleware;
+
+class FormContentHandler extends ContentHandler
+{
+    /**
+     * @inheritdoc
+     */
+    protected function isApplicableMimeType($mime)
+    {
+        return 'application/x-www-form-urlencoded' === $mime;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function getParsedBody($body)
+    {
+        parse_str($body, $parsed);
+        return $parsed;
+    }
+}

--- a/src/JsonContentHandler.php
+++ b/src/JsonContentHandler.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Relay\Middleware;
+
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+
+class JsonContentHandler extends ContentHandler
+{
+    /**
+     * @var bool
+     */
+    protected $assoc;
+
+    /**
+     * @var int
+     */
+    protected $maxDepth;
+
+    /**
+     * @var int
+     */
+    protected $options;
+
+    /**
+     * @param bool $assoc
+     * @param int  $maxDepth
+     * @param int  $options
+     */
+    public function __construct($assoc = false, $maxDepth = 512, $options = 0)
+    {
+        $this->assoc    = $assoc;
+        $this->maxDepth = $maxDepth;
+        $this->options  = $options;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function isApplicableMimeType($mime)
+    {
+        return 'application/json' === $mime
+            || 'application/vnd.api+json' === $mime;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    protected function getParsedBody($body)
+    {
+        $body = json_decode($body, $this->assoc, $this->maxDepth, $this->options);
+
+        if (json_last_error()) {
+            $this->throwException('Error parsing JSON: ' . json_last_error_msg());
+        }
+
+        return $body;
+    }
+}

--- a/tests/ContentHandlerTestCase.php
+++ b/tests/ContentHandlerTestCase.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Relay\Middleware;
+
+use Zend\Diactoros\ServerRequest;
+use Zend\Diactoros\Stream;
+
+abstract class ContentHandlerTestCase extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @param string $method
+     * @param string $mime
+     * @param string $body
+     *
+     * @return ServerRequest
+     */
+    protected function getRequest($method, $mime, $body = null)
+    {
+        $stream = new Stream('php://memory', 'w+');
+        if ($body) {
+            $stream->write($body);
+        }
+        return new ServerRequest(
+            $server  = [],
+            $upload  = [],
+            $path    = '/',
+            $method,
+            $body    = $stream,
+            $headers = [
+                'Content-Type' => $mime,
+            ]
+        );
+    }
+}

--- a/tests/FormContentHandlerTest.php
+++ b/tests/FormContentHandlerTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Relay\Middleware;
+
+use Relay\Middleware\FormContentHandler;
+use Zend\Diactoros\Response;
+
+class FormContentHandlerTest extends ContentHandlerTestCase
+{
+    public function requestData()
+    {
+        return [
+            ['POST'],
+            ['PUT'],
+            ['DELETE'],
+            ['other'],
+        ];
+    }
+
+    /**
+     * @dataProvider requestData
+     */
+    public function testInvokeWithApplicableMimeType($method)
+    {
+        $request = $this->getRequest(
+            $method,
+            $mime = 'application/x-www-form-urlencoded',
+            http_build_query($body = ['test' => 'form'], '', '&')
+        );
+        $response = new Response;
+        $handler = new FormContentHandler;
+        $resolved = $handler($request, $response, function ($req, $res) use ($mime, $body) {
+            $this->assertSame($mime, $req->getHeaderLine('Content-Type'));
+            $this->assertSame($body, $req->getParsedBody());
+            return $res;
+        });
+    }
+
+    public function testInvokeWithInvalidMethod()
+    {
+        $request = $this->getRequest(
+            $method = 'GET',
+            $mime = 'application/x-www-form-urlencoded'
+        );
+        $response = new Response;
+        $handler = new FormContentHandler;
+        $resolved = $handler($request, $response, function ($req, $res) use ($mime) {
+            $this->assertSame($mime, $req->getHeaderLine('Content-Type'));
+            $this->assertEmpty($req->getParsedBody());
+            return $res;
+        });
+    }
+
+    public function testInvokeWithNonApplicableMimeType()
+    {
+        $request = $this->getRequest(
+            $method = 'POST',
+            $mime = 'application/json',
+            $body = json_encode((object) ['test' => 'json'])
+        );
+        $response = new Response;
+        $handler = new FormContentHandler;
+        $resolved = $handler($request, $response, function ($req, $res) use ($mime) {
+            $this->assertSame($mime, $req->getHeaderLine('Content-Type'));
+            $this->assertNull($req->getParsedBody());
+            return $res;
+        });
+    }
+}

--- a/tests/JsonContentHandlerTest.php
+++ b/tests/JsonContentHandlerTest.php
@@ -1,0 +1,127 @@
+<?php
+namespace Relay\Middleware;
+
+use Zend\Diactoros\Response;
+
+class JsonContentHandlerTest extends ContentHandlerTestCase
+{
+    public function dataRequest()
+    {
+        $data = [];
+
+        foreach ([
+            'POST',
+            'PUT',
+            'DELETE',
+            'OPTIONS',
+            'other',
+        ] as $method) {
+            foreach ([
+                'application/json',
+                'application/json;charset=utf-8',
+                'application/json; charset=utf-8',
+                'application/json ; charset=utf-8',
+                'application/vnd.api+json',
+            ] as $mime) {
+                foreach ([
+                    (object) ['foo' => 'bar'],
+                    [1, 2, 3],
+                    'strings',
+                    3.14159,
+                    42,
+                    true,
+                    false,
+                    null,
+                ] as $value) {
+                    $data[] = [$method, $mime, $value, json_encode($value)];
+                }
+            }
+        }
+
+        return $data;
+    }
+
+    /**
+     * @dataProvider dataRequest
+     */
+    public function testInvoke($method, $mime, $body, $json)
+    {
+        if (is_array($body) && gettype(key($body)) === 'string') {
+            // Convert the associative array to an object
+            $body = json_decode(json_encode($body));
+        }
+
+        $request = $this->getRequest($method, $mime, $json);
+
+        $response = new Response;
+        $handler = new JsonContentHandler;
+        $resolved = $handler($request, $response, function ($req, $res) use ($mime, $body) {
+            $this->assertSame($mime, $req->getHeaderLine('Content-Type'));
+            $this->assertEquals($body, $req->getParsedBody());
+            return $res;
+        });
+    }
+
+    public function testInvokeAsArray()
+    {
+        $body = [
+            'foo' => 'bar',
+            'array' => true,
+        ];
+
+        $request = $this->getRequest('POST', 'application/json', json_encode($body));
+
+        $response = new Response;
+        $handler = new JsonContentHandler(true);
+        $resolved = $handler($request, $response, function ($req, $res) use ($body) {
+            $this->assertEquals($body, $req->getParsedBody());
+            return $res;
+        });
+    }
+
+    public function testInvokeWithInvalidMethods()
+    {
+        $request = $this->getRequest('GET', 'application/json', null);
+
+        $response = new Response;
+        $handler = new JsonContentHandler(true);
+        $resolved = $handler($request, $response, function ($req, $res) {
+            $this->assertEmpty($req->getParsedBody());
+            return $res;
+        });
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessageRegex /error parsing json: .+/i
+     */
+    public function testInvokeWithMalformedBody()
+    {
+        $request = $this->getRequest(
+            $method = 'POST',
+            $mime = 'application/json',
+            $body = '{'
+        );
+        $response = new Response;
+        $handler = new JsonContentHandler;
+        $resolved = $handler($request, $response, function ($req, $res) {
+            return $res;
+        });
+    }
+
+    public function testInvokeWithNonApplicableMimeType()
+    {
+        $request = $this->getRequest(
+            $method = 'POST',
+            $mime = 'application/x-www-form-urlencoded',
+            $body = http_build_query(['test' => 'form'], '', '&')
+        );
+        $response = new Response;
+        $handler = new JsonContentHandler;
+        $resolved = $handler($request, $response, function ($req, $res) use ($mime) {
+            $this->assertSame($mime, $req->getHeaderLine('Content-Type'));
+            $this->assertEmpty($req->getParsedBody());
+            return $res;
+        });
+    }
+}


### PR DESCRIPTION
Add middleware donated by @sparkphp:
- abstract `ContentHandler` provides a basic structure
- `JsonContentHandler` replaces `JsonDecoder`
- `FormContentHandler` adds support for form data

Improvements over `JsonDecoder` include:
- easier to extend
- exception thrown when parsing fails
- allow `application/vnd.api+json` mime type for JSON:API support

Refs #13
