### PR TITLE
Ensure session id is set to old ID

### DIFF
--- a/src/SessionHeadersHandler.php
+++ b/src/SessionHeadersHandler.php
@@ -128,6 +128,7 @@ class SessionHeadersHandler
         $cookies = $request->getCookieParams();
         if (! empty($cookies[$oldName])) {
             $oldId = $cookies[$oldName];
+            session_id($oldId);
         }
 
         // invoke the next middleware


### PR DESCRIPTION
This fixes what appears to be a bug in the original reasoning and/or assumption found in the article here: http://paul-m-jones.com/archives/6310 and solves Issue #22 wherein even with `session.use_only_cookies` was `true` the setting of `session.use_cookies` to `false` caused PHP not to read the session ID from the cookie (at least in some circumstances).

In either case, setting the `session_id()` explicitly should work for all circumstances where an old id is present.